### PR TITLE
Hyllypaikka näyviin vaikka säilytystila ei meritty

### DIFF
--- a/app/ark/konservointi/partials/loyto_tila.html
+++ b/app/ark/konservointi/partials/loyto_tila.html
@@ -14,13 +14,13 @@
 					<p class="form-control-static mip-multiline">{{vm.loyto.properties.loydon_tila | namei18n}}</p>
 				</div>
 			</div>
-			<div class="form-group" ng-if="vm.loyto.properties.sailytystila">
+			<div class="form-group" ng-if="vm.loyto.properties.sailytystila || vm.loyto.properties.vakituinen_hyllypaikka">
 				<label class="col-sm-4 control-label">
 					<span i18n="ark.Permanent_location"></span>
 				</label>
 				<div class="col-sm-8">
 					<p class="form-control-static mip-multiline">{{vm.loyto.properties.sailytystila |
-						namei18n}}.{{vm.loyto.properties.vakituinen_hyllypaikka}}</p>
+						namei18n}}<span ng-if="vm.loyto.properties.sailytystila && vm.loyto.properties.vakituinen_hyllypaikka">.</span>{{vm.loyto.properties.vakituinen_hyllypaikka}}</p>
 				</div>
 			</div>
 			<div class="form-group" ng-if="vm.loyto.properties.tilapainen_sijainti">

--- a/app/ark/konservointi/partials/nayte_tila.html
+++ b/app/ark/konservointi/partials/nayte_tila.html
@@ -17,13 +17,13 @@
 	                </p>
 	            </div>    
 	        </div>     
-	        <div class="form-group" ng-if="vm.nayte.properties.sailytystila">
+	        <div class="form-group" ng-if="vm.nayte.properties.sailytystila || vm.nayte.properties.vakituinen_hyllypaikka">
                 <label class="col-sm-4 control-label">
                     <span i18n="ark.Permanent_location"></span>
                 </label>
                 <div class="col-sm-8">
                     <p class="form-control-static mip-multiline">{{vm.nayte.properties.sailytystila |
-                        namei18n}}.{{vm.nayte.properties.vakituinen_hyllypaikka}}</p>
+                        namei18n}}<span ng-if="vm.nayte.properties.sailytystila && vm.nayte.properties.vakituinen_hyllypaikka">.</span>{{vm.nayte.properties.vakituinen_hyllypaikka}}</p>
                 </div>
             </div>
             <div class="form-group" ng-if="vm.nayte.properties.tilapainen_sijainti">

--- a/app/ark/loydot/loydot.html
+++ b/app/ark/loydot/loydot.html
@@ -114,7 +114,9 @@
                                 {{loyto.properties.paino}} {{loyto.properties.painoyksikko}}
                             </td>
                             <td data-title="vm.getColumnName('Permanent_location', 'ark')" ng-if="vm.colVisibilities.showVakituinenSijaintiCol">
-                                {{loyto.properties.sailytystila | namei18n}} {{loyto.properties.vakituinen_hyllypaikka}}
+                                <div>
+                                    {{loyto.properties.sailytystila | namei18n}}<span ng-if="loyto.properties.sailytystila && loyto.properties.vakituinen_hyllypaikka">.</span>{{loyto.properties.vakituinen_hyllypaikka}}
+                                </div>
                             </td>
                             <td data-title="vm.getColumnName('Discovery_location_extension', 'ark')" ng-if="vm.colVisibilities.showLoytopaikanTarkenneCol">
                                 {{loyto.properties.loytopaikan_tarkenne}}

--- a/app/ark/loydot/partials/loydon_tapahtuma.html
+++ b/app/ark/loydot/partials/loydon_tapahtuma.html
@@ -62,11 +62,12 @@
 										<p class="form-control-static">{{vm.tapahtuma.luoja.etunimi}} {{vm.tapahtuma.luoja.sukunimi}}</p>
 									</div>
 								</div>
-								<div class="form-group" ng-if="vm.tapahtuma.sailytystila">
+								<div class="form-group" ng-if="vm.tapahtuma.sailytystila || vm.tapahtuma.vakituinen_hyllypaikka ">
                                     <label class="col-sm-4 control-label"> <span i18n="ark.Permanent_location"></span>
                                     </label>
                                     <div class="col-sm-8">
-                                        <p class="form-control-static mip-multiline">{{vm.tapahtuma.sailytystila | namei18n}}.{{vm.tapahtuma.vakituinen_hyllypaikka}}</p>
+                                        <p class="form-control-static mip-multiline">{{vm.tapahtuma.sailytystila |
+											 namei18n}}<span ng-if="vm.tapahtuma.sailytystila && vm.tapahtuma.vakituinen_hyllypaikka">.</span>{{vm.tapahtuma.vakituinen_hyllypaikka}}</p>
                                     </div>
                                 </div>
                                 <div class="form-group" ng-if="vm.tapahtuma.tilapainen_sijainti">

--- a/app/ark/loydot/partials/tila.html
+++ b/app/ark/loydot/partials/tila.html
@@ -56,7 +56,7 @@
 					<p class="form-control-static mip-multiline">{{vm.loyto.properties.loydon_tila | namei18n}}</p>
 				</div>
 			</div>
-			<div class="form-group" ng-if="vm.loyto.properties.sailytystila">
+			<div class="form-group" ng-if="vm.loyto.properties.sailytystila || vm.loyto.properties.vakituinen_hyllypaikka">
 				<label class="col-sm-4 control-label">
 					<span i18n="ark.Permanent_location"></span>
 				</label>

--- a/app/ark/naytteet/partials/naytteen_tapahtuma.html
+++ b/app/ark/naytteet/partials/naytteen_tapahtuma.html
@@ -62,11 +62,12 @@
 										<p class="form-control-static">{{vm.tapahtuma.luoja.etunimi}} {{vm.tapahtuma.luoja.sukunimi}}</p>
 									</div>
 								</div>
-								<div class="form-group" ng-if="vm.tapahtuma.sailytystila">
+								<div class="form-group" ng-if="vm.tapahtuma.sailytystila || vm.tapahtuma.vakituinen_hyllypaikka">
                                     <label class="col-sm-4 control-label"> <span i18n="ark.Permanent_location"></span>
                                     </label>
                                     <div class="col-sm-8">
-                                        <p class="form-control-static mip-multiline">{{vm.tapahtuma.sailytystila | namei18n}}<span ng-if="vm.tapahtuma.sailytystila && vm.tapahtuma.vakituinen_hyllypaikka">.</span>{{vm.tapahtuma.vakituinen_hyllypaikka}}</p>
+                                        <p class="form-control-static mip-multiline">{{vm.tapahtuma.sailytystila |
+											 namei18n}}<span ng-if="vm.tapahtuma.sailytystila && vm.tapahtuma.vakituinen_hyllypaikka">.</span>{{vm.tapahtuma.vakituinen_hyllypaikka}}</p>
                                     </div>
                                 </div>
                                 <div class="form-group" ng-if="vm.tapahtuma.tilapainen_sijainti">


### PR DESCRIPTION
Hyllypaikka näytetään nyt vaikka säilytystilaa ei olisi merkitty. Jos molemmat ovat tiedossa, erotetaan säilytystila ja hyllypaikka pisteellä. Muutokset tehty samalla tavalla kaikkialle, missä säilytystila ja hyllypaikka näytetään samalla rivillä.  Listausnäkymässä säilytystilan ja hyllypaikan välissä oli aikaisemmin välilyönti, nyt piste kuten muuallakin.