### PR TITLE
QR koodin tulostukset ja näyte-korin qr raportti

### DIFF
--- a/app/ark/loydot/loytoController.js
+++ b/app/ark/loydot/loytoController.js
@@ -812,6 +812,11 @@ angular.module('mip.loyto').controller(
                     return locale.getString(str);
                 }
 
+                vm.printQRCode= function() {
+					sessionStorage.setItem("tunniste", vm.loyto.properties.luettelointinumero);
+					window.open("pages/templates/qrcode_printpage.html", "_blank");
+				};
+
 
                 /*
                  * Add image to the alue

--- a/app/ark/loydot/partials/loyto.html
+++ b/app/ark/loydot/partials/loyto.html
@@ -104,6 +104,8 @@
 	                        <li><a href="" ng-click="vm.addKartta()"
                                    i18n="ark.Add_map_to_list" data-ng-if="vm.permissions.muokkaus && !vm.edit && !vm.disableButtons"></a>
                             </li>
+							<li><a href="" ng-click="vm.printQRCode()" i18n="common.Print_qr_code"></a>
+							</li>
 	                         <li role="separator" class="divider"></li>
 	                        <li><a href="" ng-click="vm.close()"
 	                               i18n="common.Close"

--- a/app/ark/naytteet/nayteController.js
+++ b/app/ark/naytteet/nayteController.js
@@ -595,6 +595,11 @@ angular.module('mip.nayte').controller(
                     return locale.getString(str);
                 }
 
+				vm.printQRCode= function() {
+					sessionStorage.setItem("tunniste", vm.nayte.properties.luettelointinumero);
+					window.open("pages/templates/qrcode_printpage.html", "_blank");
+				};
+
                 /*
                  * Avaa konservointitiedot
                  */

--- a/app/ark/naytteet/partials/nayte.html
+++ b/app/ark/naytteet/partials/nayte.html
@@ -89,6 +89,7 @@
                             <li><a href="" ng-click="vm.addKartta()"
                                    i18n="ark.Add_map_to_list" data-ng-if="vm.permissions.muokkaus && !vm.edit && !vm.disableButtons"></a>
                             </li>
+							<li><a href="" ng-click="vm.printQRCode()" i18n="common.Print_qr_code"></a></li>
                             <li role="separator" class="divider" data-ng-if="vm.permissions.muokkaus && !vm.edit && !vm.disableButtons"></li>
 	                        <li><a href="" ng-click="vm.close()"
 	                               i18n="common.Close"

--- a/app/korit/koriController.js
+++ b/app/korit/koriController.js
@@ -723,10 +723,10 @@ angular.module('mip.kori').controller(
                  */
 				vm.createQRCodeReport = function() {
 					sessionStorage.setItem("korinimi", vm.kori.properties.nimi);
-					if(vm.kori.properties.korityyppi.nimi_fi == 'Löytö'){
+					if(vm.kori.properties.korityyppi.taulu == 'ark_loyto'){
 						sessionStorage.setItem("koridata", JSON.stringify(vm.loytoKoriTable.data));
 					}
-					if(vm.kori.properties.korityyppi.nimi_fi == 'Näyte'){
+					if(vm.kori.properties.korityyppi.taulu == 'ark_nayte'){
 						sessionStorage.setItem("koridata", JSON.stringify(vm.nayteKoriTable.data));
 					}
 					window.open("korit/partials/qrcode_report.html", "_blank");

--- a/app/korit/koriController.js
+++ b/app/korit/koriController.js
@@ -723,10 +723,20 @@ angular.module('mip.kori').controller(
                  */
 				vm.createQRCodeReport = function() {
 					sessionStorage.setItem("korinimi", vm.kori.properties.nimi);
-					sessionStorage.setItem("koridata", JSON.stringify(vm.loytoKoriTable.data));
+					if(vm.kori.properties.korityyppi.nimi_fi == 'Löytö'){
+						sessionStorage.setItem("koridata", JSON.stringify(vm.loytoKoriTable.data));
+					}
+					if(vm.kori.properties.korityyppi.nimi_fi == 'Näyte'){
+						sessionStorage.setItem("koridata", JSON.stringify(vm.nayteKoriTable.data));
+					}
 					window.open("korit/partials/qrcode_report.html", "_blank");
 				};
 
+				vm.printQRCode= function() {
+					sessionStorage.setItem("tunniste", vm.kori.properties.nimi);
+					window.open("pages/templates/qrcode_printpage.html", "_blank");
+				};
+				
                 /*
                  * Create a report
                  * type: PDF / WORD / EXCEL ...

--- a/app/korit/partials/kori.html
+++ b/app/korit/partials/kori.html
@@ -76,7 +76,7 @@
                             </li>
                             <li class="dropdown-submenu pull-left" ng-if="vm.mip === 'ARK' && !vm.create && !vm.edit && vm.koriValittu">
                                 <a href="" style="padding-right:65px;" i18n="common.Create_report"></a>
-                                <ul ng-if="vm.korityyppi.taulu === 'ark_loyto'" class="dropdown-menu submenuHeightFix3Elements">
+                                <ul class="dropdown-menu submenuHeightFix3Elements">
                                     <li style="cursor: pointer">
                                         <a ng-click="vm.createReport('WORD', 'loyto_luettelointikortit')"><span i18n="ark.Indexing_cards"></span> (word)</a>
                                     </li>
@@ -85,11 +85,6 @@
                                     </li>
                                     <li style="cursor: pointer">
                                         <a ng-click="vm.createQRCodeReport()"><span i18n="common.Report"></span> (QR Codes)</a>
-                                    </li>
-                                </ul>
-                                <ul ng-if="vm.korityyppi.taulu !== 'ark_loyto'" class="dropdown-menu submenuHeightFix1Elements">
-                                    <li style="cursor: pointer">
-                                        <a ng-click="vm.createReport('EXCEL', vm.korityyppi.taulu)"><span i18n="common.Report"></span> (excel)</a>
                                     </li>
                                 </ul>
                             </li>
@@ -102,6 +97,8 @@
                                     </li>
                                 </ul>
                             </li>
+                            <li><a href="" ng-click="vm.printQRCode()"
+								i18n="common.Print_qr_code"></a></li>
                             <li><a href="" ng-click="vm.close()"
                                 i18n="common.Close"
                                 ng-show="!vm.edit"></a>

--- a/app/korit/partials/kori.html
+++ b/app/korit/partials/kori.html
@@ -76,10 +76,18 @@
                             </li>
                             <li class="dropdown-submenu pull-left" ng-if="vm.mip === 'ARK' && !vm.create && !vm.edit && vm.koriValittu">
                                 <a href="" style="padding-right:65px;" i18n="common.Create_report"></a>
-                                <ul class="dropdown-menu submenuHeightFix3Elements">
+                                <ul ng-if="vm.korityyppi.taulu === 'ark_loyto'" class="dropdown-menu submenuHeightFix3Elements">
                                     <li style="cursor: pointer">
                                         <a ng-click="vm.createReport('WORD', 'loyto_luettelointikortit')"><span i18n="ark.Indexing_cards"></span> (word)</a>
                                     </li>
+                                    <li style="cursor: pointer">
+                                        <a ng-click="vm.createReport('EXCEL', vm.korityyppi.taulu)"><span i18n="common.Report"></span> (excel)</a>
+                                    </li>
+                                    <li style="cursor: pointer">
+                                        <a ng-click="vm.createQRCodeReport()"><span i18n="common.Report"></span> (QR Codes)</a>
+                                    </li>
+                                </ul>
+                                <ul ng-if="vm.korityyppi.taulu !== 'ark_loyto'" class="dropdown-menu submenuHeightFix2Elements">
                                     <li style="cursor: pointer">
                                         <a ng-click="vm.createReport('EXCEL', vm.korityyppi.taulu)"><span i18n="common.Report"></span> (excel)</a>
                                     </li>

--- a/app/languages/en-US/common.lang.json
+++ b/app/languages/en-US/common.lang.json
@@ -566,5 +566,6 @@
 	"Internal_additional_info": "Internal additional information",
 	"Scan_qrcode": "Scan QR code",
 	"Basket_name": "Basket name",
-	"Storage_code": "Storage code"
+	"Storage_code": "Storage code",
+	"Print_qr_code": "Print QR code"
 }

--- a/app/languages/fi-FI/common.lang.json
+++ b/app/languages/fi-FI/common.lang.json
@@ -567,5 +567,5 @@
 	"Scan_qrcode": "Skannaa QR koodi",
 	"Basket_name": "Korin nimi",
 	"Storage_code": "Säilytystilan koodi",
-	"Print_qr_code": "Tulosta QR-koori"
+	"Print_qr_code": "Tulosta QR-koodi"
 }

--- a/app/languages/fi-FI/common.lang.json
+++ b/app/languages/fi-FI/common.lang.json
@@ -566,5 +566,6 @@
 	"Internal_additional_info": "Sisäiset lisätiedot",
 	"Scan_qrcode": "Skannaa QR koodi",
 	"Basket_name": "Korin nimi",
-	"Storage_code": "Säilytystilan koodi"
+	"Storage_code": "Säilytystilan koodi",
+	"Print_qr_code": "Tulosta QR-koori"
 }

--- a/app/languages/sv-FI/common.lang.json
+++ b/app/languages/sv-FI/common.lang.json
@@ -566,5 +566,6 @@
 	"Internal_additional_info": "Sisäiset lisätiedot",
 	"Scan_qrcode": "Skannaa QR koodi",
 	"Basket_name": "Korin nimi",
-	"Storage_code": "Säilytystilan koodi"
+	"Storage_code": "Säilytystilan koodi",
+    "Print_qr_code": "Skriv ut QR kod"
 }

--- a/app/pages/templates/qrcode_printpage.html
+++ b/app/pages/templates/qrcode_printpage.html
@@ -1,0 +1,65 @@
+<script src="../../lib/other/angular/angular.js"></script>
+<script src="../../lib/bower_components/angular-qr/qrcode.js"></script>
+<script src="../../lib/bower_components/angular-qr/angular-qr.js"></script>
+<link rel="shortcut icon" href="#" />
+<style>
+
+    table{
+        border-collapse: collapse;
+        table-layout:fixed;
+    }
+    qr{
+        margin-left: 30px;
+        margin-right: 30px;
+    }
+    @media print {
+        body {
+            color-adjust: exact;
+            -webkit-print-color-adjust: exact;
+        }
+        table {
+            page-break-inside: avoid;
+        }
+        .pagebreak{
+            page-break-after: always;
+        }
+
+    }
+    @page
+    {
+        size: auto;   /* auto is the initial value */
+        margin-top: 0mm;
+        margin-bottom: 0mm;
+        margin-left: 30mm;
+        margin-right: 20mm;
+    }
+</style>
+<div ng-app="myApp" ng-controller="myCtrl">
+
+<table class ="pagebreak">
+    <colgroup>
+        <col style ="width:60%;" />
+        <col style="width:40%;" />
+      </colgroup>
+    <tr style ='height:15px;'></tr>
+    <tr>
+        <td>{{tunniste}}</td>
+        <td id="qrkoodi"><qr type-number="0" correction-level="'M'" size= 'qrkoodikoko' text="tunniste"></qr></td>
+    </tr>
+</table>
+</div>
+<script>
+    var app = angular.module('myApp', ['ja.qr']);
+    app.controller('myCtrl', function($scope) {
+        var vm = this;
+
+        vm.startup = function() {
+            $scope.tunniste = sessionStorage.getItem('tunniste');
+            document.title = $scope.tunniste;
+            $scope.qrkoodikoko = 100;
+            }
+
+        vm.startup();
+    });
+
+</script>


### PR DESCRIPTION
**löytö-, näyte- ja kori.hml**

-  lisätty  toimistojen alle "Tulosta QR-koodi", jonka valinta näyttää korin nimen ja vastaavan QR-koodin uudessa välilehdessä.

**löytö-, näyte- ja koriController.js**

- lisätty funktio printQRCode().

- koriControllerissa muutettu createQRCodeReport() - funktiota siten, että osaa hakea löytö-korin ja näyte-korin tiedot

**Lisätty qrcode_printpage.html**

- Muotoillaan yksittäisen QR-koodin esitystapa

**common.lang kaikilla kielillä**
- Lisätty Print_qr_code teksti kaikille kielille